### PR TITLE
1.2.4

### DIFF
--- a/BetterBetterTeleporter/BetterBetterTeleporter.csproj
+++ b/BetterBetterTeleporter/BetterBetterTeleporter.csproj
@@ -4,7 +4,7 @@
     <TeamName>jaramp</TeamName>
     <AssemblyName>BetterBetterTeleporter</AssemblyName>
     <Description>A fully configurable Teleporter and Inverse Teleporter mod with advanced item filtering.</Description>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -101,6 +101,7 @@ public static class KeepItemsOnTeleporterPatch
             Plugin.Logger.LogWarning($"Unable to verify current item is being held correctly. Error: {e}");
         }
         Plugin.Logger.LogDebug("Finished restoring player inventory");
+        TeleportDetectionPatch.AfterTeleporterDropAllHeldItems();
     }
 
     private static IEnumerator RefreshInventory(PlayerControllerB __instance, float carryWeightDelta, bool isInverse)

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -72,8 +72,13 @@ public static class KeepItemsOnTeleporterPatch
                 if (keptItem == null) continue;
 
                 __instance.ItemSlots[i] = keptItem;
-                HUDManager.Instance.itemSlotIcons[i].enabled = true;
                 carryWeightDelta += keptItem.itemProperties.weight - 1f;
+
+                // HUDManager manages local state: only run for teleported player
+                if (__instance.actualClientId == NetworkManager.Singleton.LocalClientId)
+                {
+                    HUDManager.Instance.itemSlotIcons[i].enabled = true;
+                }
             }
             NetworkManager.Singleton.StartCoroutine(RefreshInventory(__instance, carryWeightDelta, isInverse));
         }

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -20,7 +20,9 @@ public static class KeepItemsOnTeleporterPatch
     [HarmonyPrefix]
     public static void DropAllHeldItemsPrefix(PlayerControllerB __instance)
     {
+        Plugin.Logger.LogDebug("Checking if player is teleporting");
         if (!TeleportDetectionPatch.IsTeleporting(__instance)) return;
+        Plugin.Logger.LogDebug("Player is teleporting");
 
         var restoreOnCatch = (GrabbableObject[])__instance.ItemSlots.Clone();
         try
@@ -55,6 +57,7 @@ public static class KeepItemsOnTeleporterPatch
     [HarmonyPostfix]
     public static void DropAllHeldItemsPostfix(PlayerControllerB __instance)
     {
+        Plugin.Logger.LogDebug("Restoring player inventory");
         if (!tempInventories.ContainsKey(__instance)) return;
 
         // Restore player's inventory from temporary storage
@@ -97,6 +100,7 @@ public static class KeepItemsOnTeleporterPatch
         {
             Plugin.Logger.LogWarning($"Unable to verify current item is being held correctly. Error: {e}");
         }
+        Plugin.Logger.LogDebug("Finished restoring player inventory");
     }
 
     private static IEnumerator RefreshInventory(PlayerControllerB __instance, float carryWeightDelta, bool isInverse)

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -41,7 +41,7 @@ public static class KeepItemsOnTeleporterPatch
             // Temporarily store cloned inventory so we can restore it on Postfix
             tempInventories[__instance] = itemsToKeep;
         }
-        catch (System.Exception e)
+        catch
         {
             // Return true (default behavior) so the original DropAllHeldItemsAndSync runs normally.
             tempInventories.Remove(__instance);

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -11,14 +11,14 @@ using UnityEngine;
 
 namespace BetterBetterTeleporter.Patches;
 
-[HarmonyPatch(typeof(PlayerControllerB), "DropAllHeldItemsAndSync")]
+[HarmonyPatch(typeof(PlayerControllerB), "DropAllHeldItems")]
 public static class KeepItemsOnTeleporterPatch
 {
     private static readonly Dictionary<PlayerControllerB, GrabbableObject[]> tempInventories = [];
     private static readonly MethodInfo SwitchToItemSlotMethod = AccessTools.Method(typeof(PlayerControllerB), "SwitchToItemSlot");
 
     [HarmonyPrefix]
-    public static void DropAllHeldItemsAndSyncPrefix(PlayerControllerB __instance)
+    public static void DropAllHeldItemsPrefix(PlayerControllerB __instance)
     {
         if (!TeleportDetectionPatch.IsTeleporting(__instance)) return;
 
@@ -32,10 +32,10 @@ public static class KeepItemsOnTeleporterPatch
             for (int i = 0; i < __instance.ItemSlots.Length; i++)
             {
                 if (playerInfo.ShouldDropItem(playerInfo.Slots[i], state)) itemsToKeep[i] = null;
-                else __instance.ItemSlots[i] = null; // Hide from DropAllHeldItemsAndSync to prevent dropping
+                else __instance.ItemSlots[i] = null; // Hide from DropAllHeldItems to prevent dropping
             }
 
-            // Suppress drop animation call from DropAllHeldItemsAndSync
+            // Suppress drop animation call from DropAllHeldItems
             __instance.isHoldingObject = __instance.ItemSlots[__instance.currentItemSlot] != null;
 
             // Temporarily store cloned inventory so we can restore it on Postfix
@@ -43,7 +43,7 @@ public static class KeepItemsOnTeleporterPatch
         }
         catch
         {
-            // Return true (default behavior) so the original DropAllHeldItemsAndSync runs normally.
+            // Return true (default behavior) so the original DropAllHeldItems runs normally.
             tempInventories.Remove(__instance);
             for (int i = 0; i < __instance.ItemSlots.Length; i++)
             {
@@ -53,7 +53,7 @@ public static class KeepItemsOnTeleporterPatch
     }
 
     [HarmonyPostfix]
-    public static void DropAllHeldItemsAndSyncPostfix(PlayerControllerB __instance)
+    public static void DropAllHeldItemsPostfix(PlayerControllerB __instance)
     {
         if (!tempInventories.ContainsKey(__instance)) return;
 
@@ -77,7 +77,7 @@ public static class KeepItemsOnTeleporterPatch
             }
             NetworkManager.Singleton.StartCoroutine(RefreshInventory(__instance, carryWeightDelta, isInverse));
         }
-        catch (System.Exception e)
+        catch (Exception e)
         {
             Plugin.Logger.LogError($"Failed to restore inventory. Error: {e}");
         }
@@ -88,7 +88,7 @@ public static class KeepItemsOnTeleporterPatch
             __instance.isHoldingObject = __instance.ItemSlots[__instance.currentItemSlot] != null;
             SwitchToItemSlotMethod.Invoke(__instance, [__instance.currentItemSlot, null]);
         }
-        catch (System.Exception e)
+        catch (Exception e)
         {
             Plugin.Logger.LogWarning($"Unable to verify current item is being held correctly. Error: {e}");
         }
@@ -99,7 +99,7 @@ public static class KeepItemsOnTeleporterPatch
         // Wait for other mods to resolve weight
         yield return new WaitForEndOfFrame();
 
-        // DropAllHeldItemsAndSync resets weight: need to manually add back current inventory weight
+        // DropAllHeldItems resets weight: need to manually add back current inventory weight
         __instance.carryWeight = Mathf.Clamp(__instance.carryWeight + carryWeightDelta, 1f, 10f);
 
         // Update inventory items to match new player position

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -20,9 +20,7 @@ public static class KeepItemsOnTeleporterPatch
     [HarmonyPrefix]
     public static void DropAllHeldItemsPrefix(PlayerControllerB __instance)
     {
-        Plugin.Logger.LogDebug("Checking if player is teleporting");
         if (!TeleportDetectionPatch.IsTeleporting(__instance)) return;
-        Plugin.Logger.LogDebug("Player is teleporting");
 
         var restoreOnCatch = (GrabbableObject[])__instance.ItemSlots.Clone();
         try
@@ -57,7 +55,6 @@ public static class KeepItemsOnTeleporterPatch
     [HarmonyPostfix]
     public static void DropAllHeldItemsPostfix(PlayerControllerB __instance)
     {
-        Plugin.Logger.LogDebug("Restoring player inventory");
         if (!tempInventories.ContainsKey(__instance)) return;
 
         // Restore player's inventory from temporary storage
@@ -100,7 +97,6 @@ public static class KeepItemsOnTeleporterPatch
         {
             Plugin.Logger.LogWarning($"Unable to verify current item is being held correctly. Error: {e}");
         }
-        Plugin.Logger.LogDebug("Finished restoring player inventory");
         TeleportDetectionPatch.AfterTeleporterDropAllHeldItems();
     }
 

--- a/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
+++ b/BetterBetterTeleporter/Patches/KeepItemsOnTeleportPatch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,14 +11,14 @@ using UnityEngine;
 
 namespace BetterBetterTeleporter.Patches;
 
-[HarmonyPatch(typeof(PlayerControllerB), "DropAllHeldItems")]
+[HarmonyPatch(typeof(PlayerControllerB), "DropAllHeldItemsAndSync")]
 public static class KeepItemsOnTeleporterPatch
 {
     private static readonly Dictionary<PlayerControllerB, GrabbableObject[]> tempInventories = [];
     private static readonly MethodInfo SwitchToItemSlotMethod = AccessTools.Method(typeof(PlayerControllerB), "SwitchToItemSlot");
 
     [HarmonyPrefix]
-    public static void DropAllHeldItemsPrefix(PlayerControllerB __instance)
+    public static void DropAllHeldItemsAndSyncPrefix(PlayerControllerB __instance)
     {
         if (!TeleportDetectionPatch.IsTeleporting(__instance)) return;
 
@@ -31,10 +32,10 @@ public static class KeepItemsOnTeleporterPatch
             for (int i = 0; i < __instance.ItemSlots.Length; i++)
             {
                 if (playerInfo.ShouldDropItem(playerInfo.Slots[i], state)) itemsToKeep[i] = null;
-                else __instance.ItemSlots[i] = null; // Hide from DropAllHeldItems to prevent dropping
+                else __instance.ItemSlots[i] = null; // Hide from DropAllHeldItemsAndSync to prevent dropping
             }
 
-            // Suppress drop animation call from DropAllHeldItems
+            // Suppress drop animation call from DropAllHeldItemsAndSync
             __instance.isHoldingObject = __instance.ItemSlots[__instance.currentItemSlot] != null;
 
             // Temporarily store cloned inventory so we can restore it on Postfix
@@ -42,8 +43,7 @@ public static class KeepItemsOnTeleporterPatch
         }
         catch (System.Exception e)
         {
-            Plugin.Logger.LogError($"Failed to intercept DropAllHeldItems (Prefix). Falling back to native behavior. Error: {e}");
-            // Return true (default behavior) so the original DropAllHeldItems runs normally.
+            // Return true (default behavior) so the original DropAllHeldItemsAndSync runs normally.
             tempInventories.Remove(__instance);
             for (int i = 0; i < __instance.ItemSlots.Length; i++)
             {
@@ -53,7 +53,7 @@ public static class KeepItemsOnTeleporterPatch
     }
 
     [HarmonyPostfix]
-    public static void DropAllHeldItemsPostfix(PlayerControllerB __instance)
+    public static void DropAllHeldItemsAndSyncPostfix(PlayerControllerB __instance)
     {
         if (!tempInventories.ContainsKey(__instance)) return;
 
@@ -72,6 +72,7 @@ public static class KeepItemsOnTeleporterPatch
                 if (keptItem == null) continue;
 
                 __instance.ItemSlots[i] = keptItem;
+                HUDManager.Instance.itemSlotIcons[i].enabled = true;
                 carryWeightDelta += keptItem.itemProperties.weight - 1f;
             }
             NetworkManager.Singleton.StartCoroutine(RefreshInventory(__instance, carryWeightDelta, isInverse));
@@ -98,7 +99,7 @@ public static class KeepItemsOnTeleporterPatch
         // Wait for other mods to resolve weight
         yield return new WaitForEndOfFrame();
 
-        // DropAllHeldItems resets weight: need to manually add back current inventory weight
+        // DropAllHeldItemsAndSync resets weight: need to manually add back current inventory weight
         __instance.carryWeight = Mathf.Clamp(__instance.carryWeight + carryWeightDelta, 1f, 10f);
 
         // Update inventory items to match new player position

--- a/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
+++ b/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
@@ -29,16 +29,22 @@ public static class TeleportDetectionPatch
     [HarmonyTranspiler]
     static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
     {
-        var dropAllHeldItemsAndSyncMethod = AccessTools.Method(typeof(PlayerControllerB), "DropAllHeldItemsAndSync");
-        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItemsAndSync));
-
+        var waitForSecondsCtor = AccessTools.Constructor(typeof(UnityEngine.WaitForSeconds), [typeof(float)]);
+        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItems));
+        int waitCount = 0;
         foreach (var instruction in instructions)
         {
-            if (instruction.Calls(dropAllHeldItemsAndSyncMethod))
-            {
-                yield return new CodeInstruction(OpCodes.Call, beforeMethod);
-            }
             yield return instruction;
+
+            if (instruction.opcode == OpCodes.Newobj && Equals(instruction.operand, waitForSecondsCtor))
+            {
+                waitCount++;
+
+                if (waitCount == 2)
+                {
+                    yield return new CodeInstruction(OpCodes.Call, beforeMethod);
+                }
+            }
         }
     }
 
@@ -46,12 +52,12 @@ public static class TeleportDetectionPatch
     [HarmonyFinalizer]
     static System.Exception TeleporterFinalizer(System.Exception __exception)
     {
-        AfterTeleporterDropAllHeldItemsAndSync();
+        AfterTeleporterDropAllHeldItems();
         return __exception;
     }
 
-    public static void BeforeTeleporterDropAllHeldItemsAndSync() => isTeleporting = true;
-    public static void AfterTeleporterDropAllHeldItemsAndSync() => isTeleporting = false;
+    public static void BeforeTeleporterDropAllHeldItems() => isTeleporting = true;
+    public static void AfterTeleporterDropAllHeldItems() => isTeleporting = true;
     public static bool IsRegularTeleporting() => isTeleporting;
 
     private static readonly HashSet<int> InverseTeleportingPlayers = [];

--- a/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
+++ b/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 using GameNetcodeStuff;
 using HarmonyLib;
 
@@ -28,27 +29,26 @@ public static class TeleportDetectionPatch
 
     private static bool isTeleporting;
 
-    [HarmonyPatch("beamUpPlayer")]
-    [HarmonyPostfix]
-    private static void BeamUpPlayerPostfix(ref IEnumerator __result)
+    [HarmonyPatch("beamUpPlayer", MethodType.Enumerator)]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
     {
-        __result = WrappedBeamUpPlayer(__result);
-    }
+        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItems));
+        var code = new List<CodeInstruction>(instructions);
+        int stateResetCount = 0;
 
-    private static IEnumerator WrappedBeamUpPlayer(IEnumerator original)
-    {
-        Plugin.Logger.LogDebug("Enabling teleport item logic");
-        BeforeTeleporterDropAllHeldItems();
-
-        try
+        for (int i = 0; i < code.Count; i++)
         {
-            while (original.MoveNext())
-                yield return original.Current;
-        }
-        finally
-        {
-            AfterTeleporterDropAllHeldItems();
-            Plugin.Logger.LogDebug("Disabling teleport item logic");
+            var instruction = code[i];
+            yield return instruction;
+            if (instruction.opcode == OpCodes.Ldc_I4_M1 && i + 1 < code.Count && code[i + 1].opcode == OpCodes.Stfld)
+            {
+                stateResetCount++;
+                if (stateResetCount == 3)
+                {
+                    yield return new CodeInstruction(OpCodes.Call, beforeMethod);
+                }
+            }
         }
     }
 

--- a/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
+++ b/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
@@ -1,5 +1,5 @@
+using System.Collections;
 using System.Collections.Generic;
-using System.Reflection.Emit;
 using GameNetcodeStuff;
 using HarmonyLib;
 
@@ -17,6 +17,9 @@ public static class TeleportDetectionPatch
         if (!StartOfRound.Instance.ClientPlayerList.ContainsKey(player.actualClientId))
             return false; // Player is disconnecting
 
+        if (player.isPlayerDead || player.disableInteract)
+            return false; // Player is incapacitated
+
         if (IsRegularTeleporting()) return true;
         if (IsInverseTeleporting(player)) return true;
 
@@ -25,45 +28,46 @@ public static class TeleportDetectionPatch
 
     private static bool isTeleporting;
 
-    [HarmonyPatch("beamUpPlayer", MethodType.Enumerator)]
-    [HarmonyTranspiler]
-    static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
+    [HarmonyPatch("beamUpPlayer")]
+    [HarmonyPostfix]
+    private static void BeamUpPlayerPostfix(ref IEnumerator __result)
     {
-        var waitForSecondsCtor = AccessTools.Constructor(typeof(UnityEngine.WaitForSeconds), [typeof(float)]);
-        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItems));
-        int waitCount = 0;
-        foreach (var instruction in instructions)
+        __result = WrappedBeamUpPlayer(__result);
+    }
+
+    private static IEnumerator WrappedBeamUpPlayer(IEnumerator original)
+    {
+        Plugin.Logger.LogDebug("Enabling teleport item logic");
+        BeforeTeleporterDropAllHeldItems();
+
+        try
         {
-            yield return instruction;
-
-            if (instruction.opcode == OpCodes.Newobj && Equals(instruction.operand, waitForSecondsCtor))
-            {
-                waitCount++;
-
-                if (waitCount == 2)
-                {
-                    yield return new CodeInstruction(OpCodes.Call, beforeMethod);
-                }
-            }
+            while (original.MoveNext())
+                yield return original.Current;
+        }
+        finally
+        {
+            AfterTeleporterDropAllHeldItems();
+            Plugin.Logger.LogDebug("Disabling teleport item logic");
         }
     }
 
-    [HarmonyPatch("beamUpPlayer", MethodType.Enumerator)]
-    [HarmonyFinalizer]
-    static System.Exception TeleporterFinalizer(System.Exception __exception)
-    {
-        AfterTeleporterDropAllHeldItems();
-        return __exception;
-    }
-
     public static void BeforeTeleporterDropAllHeldItems() => isTeleporting = true;
-    public static void AfterTeleporterDropAllHeldItems() => isTeleporting = true;
+    public static void AfterTeleporterDropAllHeldItems() => isTeleporting = false;
     public static bool IsRegularTeleporting() => isTeleporting;
 
     private static readonly HashSet<int> InverseTeleportingPlayers = [];
-    public static bool IsInverseTeleporting(PlayerControllerB player) => InverseTeleportingPlayers.Contains((int)player.playerClientId);
-    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter"), HarmonyPrefix]
-    public static void TeleportPlayerOutWithInverseTeleporterPrefix(int playerObj) => InverseTeleportingPlayers.Add(playerObj);
-    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter"), HarmonyPostfix]
-    public static void TeleportPlayerOutWithInverseTeleporterPostfix(int playerObj) => InverseTeleportingPlayers.Remove(playerObj);
+
+    public static bool IsInverseTeleporting(PlayerControllerB player)
+        => InverseTeleportingPlayers.Contains((int)player.playerClientId);
+
+    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter")]
+    [HarmonyPrefix]
+    public static void TeleportPlayerOutWithInverseTeleporterPrefix(int playerObj)
+        => InverseTeleportingPlayers.Add(playerObj);
+
+    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter")]
+    [HarmonyPostfix]
+    public static void TeleportPlayerOutWithInverseTeleporterPostfix(int playerObj)
+        => InverseTeleportingPlayers.Remove(playerObj);
 }

--- a/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
+++ b/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
@@ -31,7 +31,7 @@ public static class TeleportDetectionPatch
 
     [HarmonyPatch("beamUpPlayer", MethodType.Enumerator)]
     [HarmonyTranspiler]
-    private static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
+    static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
     {
         var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItems));
         var code = new List<CodeInstruction>(instructions);
@@ -57,17 +57,9 @@ public static class TeleportDetectionPatch
     public static bool IsRegularTeleporting() => isTeleporting;
 
     private static readonly HashSet<int> InverseTeleportingPlayers = [];
-
-    public static bool IsInverseTeleporting(PlayerControllerB player)
-        => InverseTeleportingPlayers.Contains((int)player.playerClientId);
-
-    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter")]
-    [HarmonyPrefix]
-    public static void TeleportPlayerOutWithInverseTeleporterPrefix(int playerObj)
-        => InverseTeleportingPlayers.Add(playerObj);
-
-    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter")]
-    [HarmonyPostfix]
-    public static void TeleportPlayerOutWithInverseTeleporterPostfix(int playerObj)
-        => InverseTeleportingPlayers.Remove(playerObj);
+    public static bool IsInverseTeleporting(PlayerControllerB player) => InverseTeleportingPlayers.Contains((int)player.playerClientId);
+    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter"), HarmonyPrefix]
+    public static void TeleportPlayerOutWithInverseTeleporterPrefix(int playerObj) => InverseTeleportingPlayers.Add(playerObj);
+    [HarmonyPatch("TeleportPlayerOutWithInverseTeleporter"), HarmonyPostfix]
+    public static void TeleportPlayerOutWithInverseTeleporterPostfix(int playerObj) => InverseTeleportingPlayers.Remove(playerObj);
 }

--- a/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
+++ b/BetterBetterTeleporter/Patches/TeleportDetectionPatch.cs
@@ -29,12 +29,12 @@ public static class TeleportDetectionPatch
     [HarmonyTranspiler]
     static IEnumerable<CodeInstruction> TeleporterTranspiler(IEnumerable<CodeInstruction> instructions)
     {
-        var dropAllHeldItemsMethod = AccessTools.Method(typeof(PlayerControllerB), "DropAllHeldItems");
-        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItems));
+        var dropAllHeldItemsAndSyncMethod = AccessTools.Method(typeof(PlayerControllerB), "DropAllHeldItemsAndSync");
+        var beforeMethod = AccessTools.Method(typeof(TeleportDetectionPatch), nameof(BeforeTeleporterDropAllHeldItemsAndSync));
 
         foreach (var instruction in instructions)
         {
-            if (instruction.Calls(dropAllHeldItemsMethod))
+            if (instruction.Calls(dropAllHeldItemsAndSyncMethod))
             {
                 yield return new CodeInstruction(OpCodes.Call, beforeMethod);
             }
@@ -46,12 +46,12 @@ public static class TeleportDetectionPatch
     [HarmonyFinalizer]
     static System.Exception TeleporterFinalizer(System.Exception __exception)
     {
-        AfterTeleporterDropAllHeldItems();
+        AfterTeleporterDropAllHeldItemsAndSync();
         return __exception;
     }
 
-    public static void BeforeTeleporterDropAllHeldItems() => isTeleporting = true;
-    public static void AfterTeleporterDropAllHeldItems() => isTeleporting = false;
+    public static void BeforeTeleporterDropAllHeldItemsAndSync() => isTeleporting = true;
+    public static void AfterTeleporterDropAllHeldItemsAndSync() => isTeleporting = false;
     public static bool IsRegularTeleporting() => isTeleporting;
 
     private static readonly HashSet<int> InverseTeleportingPlayers = [];

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,5 +19,8 @@
         <Reference Include="UnityEngine.CoreModule">
             <HintPath>$(GameDir)\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
+        <Reference Include="UnityEngine.UI">
+            <HintPath>$(GameDir)\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
+        </Reference>
     </ItemGroup>
 </Project>

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.2.4
+
+- Compatibility update for v80
+
 ## Version 1.2.3
 
 - Fix issue with lightning strikes on conductive items after teleporting

--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "BetterBetterTeleporter",
-  "version_number": "1.2.3",
+  "version_number": "1.2.4",
   "website_url": "https://github.com/jaramp/better-better-teleporter",
   "description": "A fully configurable Teleporter and Inverse Teleporter mod with advanced item filtering.",
   "dependencies": [


### PR DESCRIPTION
v80 changed the way items are dropped in many locations, including `beamUpPlayer`. Additionally, the call to drop items is wrapped inside a local client check, since it makes an RPC call to sync dropped items.

Had to do some annoying IL code parsing to find a location to inject my detection outside of that local check so that it runs for all clients. Additionally, due to the RPC creating race conditions, I had to move the logic for finishing the teleport. I put this inside the inventory restoration to ensure it runs at the correct time on all clients. I don't think it causes problems there.

Lightly tested and verified certain scenarios like dying while getting teleported still work correctly. I don't think there should be major compatibility issues since the changes were mostly isolated to the detection logic, while the drop logic was relatively unchanged. Needed a HUD fix to prevent held items' icons from disappearing on teleport.

This is probably good enough to ship. It seems to be working for the cases I've tested.